### PR TITLE
Updated Run2Selection in order to use the newest effective areas for …

### DIFF
--- a/Selection/interface/Run2Selection.h
+++ b/Selection/interface/Run2Selection.h
@@ -94,8 +94,8 @@ public:
 
 
     void setElectronIsoCorrType(int corrType = 1);
-    float GetElectronIsoCorrType(TRootElectron* el) const;
-    float pfElectronIso(TRootElectron *el) const;
+    float GetElectronIsoCorrType(TRootElectron* el, bool bx25) const;
+    float pfElectronIso(TRootElectron *el, bool bx25 = true) const;
 // ELECTRON GETTERS ===============================================
     std::vector<TRootElectron*> GetSelectedElectrons() const;
 	std::vector<TRootElectron*> GetSelectedElectrons(string WorkingPoint, string ProductionCampaign, bool CutsBased) const;


### PR DESCRIPTION
…Electron isolation.  The function pfElectronIso has been altered to require a boolean as a second argument.  This boolean determines which set of effective areas to use.  See Run2Selection.cc for further documentation.
